### PR TITLE
Route level middleware doesn't prepare a response and causes errors

### DIFF
--- a/app/Containers/Authentication/Middlewares/WebAuthentication.php
+++ b/app/Containers/Authentication/Middlewares/WebAuthentication.php
@@ -51,7 +51,7 @@ class WebAuthentication
     public function handle(Request $request, Closure $next)
     {
         if ($this->auth->guest()) {
-            return view($this->portButler->getLoginWebPageName());
+            return response()->view($this->portButler->getLoginWebPageName());
         }
 
         return $next($request);


### PR DESCRIPTION
such as...

Symfony\Component\Debug\Exception\FatalThrowableError: Call to a member function setCookie() on null
in /vendor/laravel/framework/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php:136

...whilst trying to access a protected web view