### PR TITLE
Prevent overide middlewares fix

### DIFF
--- a/app/Ship/Engine/Loaders/MiddlewaresLoaderTrait.php
+++ b/app/Ship/Engine/Loaders/MiddlewaresLoaderTrait.php
@@ -45,8 +45,12 @@ trait MiddlewaresLoaderTrait
     private function registerMiddlewareGroups(array $middlewareGroups = [])
     {
         foreach ($middlewareGroups as $key => $middleware) {
-            if ($middleware) {
-                $this->app['router']->middlewareGroup($key, $middleware);
+            if (!is_array($middleware)) {
+                $this->app['router']->pushMiddlewareToGroup($key, $middleware);
+            } else {
+                foreach ($middleware as $item) {
+                    $this->app['router']->pushMiddlewareToGroup($key, $item);
+                }
             }
         }
     }


### PR DESCRIPTION
Avoid to override middleware when Containers middleware service providers are loaded. Closes #102 