### PR TITLE
fix displaying form requests validation errors on web routes

### DIFF
--- a/.env.travis
+++ b/.env.travis
@@ -1,6 +1,8 @@
 APP_ENV=testing
 HASH_ID=true
 
+APP_KEY=
+
 APP_URL=hello.dev
 APP_FULL_URL=http://hello.dev
 API_DOMAIN=api.hello.dev

--- a/.env.travis
+++ b/.env.travis
@@ -7,6 +7,8 @@ APP_URL=hello.dev
 APP_FULL_URL=http://hello.dev
 API_DOMAIN=api.hello.dev
 
+API_NAME="Hello API"
+
 DB_CONNECTION=mysql
 DB_HOST=localhost
 DB_DATABASE=homestead

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ before_script:
 - mysql -e 'create database homestead;'
 - travis_retry composer self-update
 - composer install --prefer-source --no-interaction --dev
+- php artisan key:generate
 - php artisan migrate --seed
 
 script: vendor/bin/phpunit

--- a/app/Containers/Authentication/UI/WEB/Tests/Functional/UserLoginTest.php
+++ b/app/Containers/Authentication/UI/WEB/Tests/Functional/UserLoginTest.php
@@ -14,7 +14,22 @@ use Illuminate\Foundation\Testing\WithoutMiddleware;
  */
 class UserLoginTest extends TestCase
 {
-    use WithoutMiddleware;
+    public function setUp()
+    {
+        // we change the API_PREFIX for web routes to make available all the
+        // right web behavior. Maybe this should be seted up on
+        // TestCaseTrait->overrideSubDomain() method?
+        putenv("API_PREFIX=api");
+
+        parent::setUp();
+    }
+
+    public function tearDown()
+    {
+        // revert the API_PREFIX variable to null to avoid effects on other test
+        putenv("API_PREFIX=");
+        parent::tearDown();
+    }
 
     // overrides the default subDomain in the base URL
     protected $subDomain = 'admin';
@@ -52,5 +67,23 @@ class UserLoginTest extends TestCase
         // we are redirected to the login page and we see errors
         $this->seePageIs($this->endpoint)
             ->see('Credentials Incorrect.');
+    }
+
+    public function checkValidationMessages()
+    {
+        // go to the page
+        $this->visit($this->endpoint)
+            ->seePageIs($this->endpoint)
+            ->see('Login');
+
+        // fill the login form with wrong credentials
+        $this->type('', 'email')
+            ->type('', 'password')
+            ->press('login');
+        
+        // we are redirected to the login page and we see validation errors
+        $this->seePageIs($this->endpoint)
+            ->see('email field is required.')
+            ->see('password field is required.');
     }
 }

--- a/app/Containers/Authentication/UI/WEB/Tests/Functional/UserLogoutTest.php
+++ b/app/Containers/Authentication/UI/WEB/Tests/Functional/UserLogoutTest.php
@@ -14,11 +14,26 @@ use Illuminate\Foundation\Testing\WithoutMiddleware;
  */
 class UserLogoutTest extends TestCase
 {
-    use WithoutMiddleware;
-
     // overrides the default subDomain in the base URL
     protected $subDomain = 'admin';
     protected $endpoint = '/logout';
+
+    public function setUp()
+    {
+        // we change the API_PREFIX for web routes to make available all the
+        // right web behavior. Maybe this should be seted up on
+        // TestCaseTrait->overrideSubDomain() method?
+        putenv("API_PREFIX=api");
+
+        parent::setUp();
+    }
+
+    public function tearDown()
+    {
+        // revert the API_PREFIX variable to null to avoid effects on other test
+        putenv("API_PREFIX=");
+        parent::tearDown();
+    }
 
     public function testUserLogout()
     {

--- a/app/Containers/Authentication/UI/WEB/Views/login.blade.php
+++ b/app/Containers/Authentication/UI/WEB/Views/login.blade.php
@@ -119,9 +119,9 @@
                     <div class="text-red">{{ session('status') }}</div>
                 @endif
                 <input type="text"  placeholder="email" id="email" name="email"/>
+                <span class="text-red">{{ $errors->first('email') }}</span>
                 <input type="password" placeholder="password" id="password" name="password"/>
-
-                <div class="text-red">{{ isset($errorMessage) ? $errorMessage : '' }}</div>
+                <span class="text-red">{{ $errors->first('password') }}</span>
 
                 <button>login</button>
             </form>

--- a/app/Containers/Localization/Configs/localization.php
+++ b/app/Containers/Localization/Configs/localization.php
@@ -14,8 +14,9 @@ return [
     */
 
     'supported_languages' => [
-        'en' => 'English',
         'ar' => 'Arabic',
+        'en' => 'English',
+        'es' => 'Spanish',
         'fr' => 'French',
     ],
 

--- a/app/Containers/Localization/Resources/Languages/es/messages.php
+++ b/app/Containers/Localization/Resources/Languages/es/messages.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+
+    'welcome' => 'Bienvenido a Hello API',
+
+];

--- a/app/Containers/Welcome/UI/WEB/Tests/Acceptance/WelcomeTest.php
+++ b/app/Containers/Welcome/UI/WEB/Tests/Acceptance/WelcomeTest.php
@@ -17,18 +17,8 @@ class WelcomeTest extends TestCase
     public function testDisplayWelcomeView()
     {
 
-        // TODO: this is causing the following error:
-        // (InvalidArgumentException: Expecting a DOMNodeList or DOMNode instance, an array, a string, or null, but got "Illuminate\View\View".)
-        // This is probably because of the Dingo package since it's response is being used for everything even web requests..
-        // or caused after upgrading to laravel 5.2 because of the composer requirement of `"symfony/dom-crawler": "2.8.*|3.0.*"` in case
-        // the crawler class was updated..
-        // if you go to `Illuminate/Foundation/Testing/Concerns/InteractsWithPages.php` and this `dd(get_class($this->response));` to line 83
-        // you should see `Dingo\Api\Http\Response` which when we call `->getContent()` on it returns `Illuminate\View\View`
-        // while the Crawler `vendor/symfony/dom-crawler/Crawler.php` is expecting other things as the error states.
-        // I will fix this later...
-
-//        $this->visit($this->page)
-//            ->see('Hello API');
+       $this->visit($this->page)
+           ->see('Hello API');
 
     }
 

--- a/app/Ship/Parents/Requests/RequestTrait.php
+++ b/app/Ship/Parents/Requests/RequestTrait.php
@@ -4,6 +4,7 @@ namespace App\Ship\Parents\Requests;
 
 use App\Ship\Features\Exceptions\ValidationFailedException;
 use Illuminate\Contracts\Validation\Validator;
+use Dingo\Api\Http\Request as DingoRequest;
 
 /**
  * Class RequestTrait
@@ -40,7 +41,11 @@ trait RequestTrait
      */
     public function failedValidation(Validator $validator)
     {
-        throw new ValidationFailedException($validator->getMessageBag());
+        if ($this->container['request'] instanceof DingoRequest) {
+            throw new ValidationFailedException($validator->getMessageBag());
+        }
+
+        parent::failedValidation($validator);
     }
 
 

--- a/resources/lang/ar/auth.php
+++ b/resources/lang/ar/auth.php
@@ -1,0 +1,19 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Authentication Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used during authentication for various
+    | messages that we need to display to the user. You are free to modify
+    | these language lines according to your application's requirements.
+    |
+    */
+
+    'failed'   => 'بيانات الاعتماد هذه غير متطابقة مع البيانات المسجلة لدينا.',
+    'throttle' => 'عدد كبير جدا من محاولات الدخول. يرجى المحاولة مرة أخرى بعد :seconds ثانية.',
+
+];

--- a/resources/lang/ar/pagination.php
+++ b/resources/lang/ar/pagination.php
@@ -1,0 +1,19 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Pagination Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used by the paginator library to build
+    | the simple pagination links. You are free to change them to anything
+    | you want to customize your views to better match your application.
+    |
+    */
+
+    'previous' => '&laquo; السابق',
+    'next'     => 'التالي &raquo;',
+
+];

--- a/resources/lang/ar/passwords.php
+++ b/resources/lang/ar/passwords.php
@@ -1,0 +1,22 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Password Reminder Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are the default lines which match reasons
+    | that are given by the password broker for a password update attempt
+    | has failed, such as for an invalid token or invalid new password.
+    |
+    */
+
+    'password' => 'يجب أن لا يقل طول كلمة المرور عن ستة أحرف، كما يجب أن تتطابق مع حقل التأكيد',
+    'reset'    => 'تمت إعادة تعيين كلمة المرور',
+    'sent'     => 'تم إرسال تفاصيل استعادة كلمة المرور الخاصة بك إلى بريدك الإلكتروني',
+    'token'    => '.رمز استعادة كلمة المرور الذي أدخلته غير صحيح',
+    'user'     => 'لم يتم العثور على أيّ حسابٍ بهذا العنوان الإلكتروني',
+
+];

--- a/resources/lang/ar/validation.php
+++ b/resources/lang/ar/validation.php
@@ -1,0 +1,149 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Validation Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines contain the default error messages used by
+    | the validator class. Some of these rules have multiple versions such
+    | such as the size rules. Feel free to tweak each of these messages.
+    |
+    */
+
+    'accepted'             => 'يجب قبول الحقل :attribute',
+    'active_url'           => 'الحقل :attribute لا يُمثّل رابطًا صحيحًا',
+    'after'                => 'يجب على الحقل :attribute أن يكون تاريخًا لاحقًا للتاريخ :date.',
+    'after_or_equal'       => 'The :attribute must be a date after or equal to :date.',
+    'alpha'                => 'يجب أن لا يحتوي الحقل :attribute سوى على حروف',
+    'alpha_dash'           => 'يجب أن لا يحتوي الحقل :attribute على حروف، أرقام ومطّات.',
+    'alpha_num'            => 'يجب أن يحتوي :attribute على حروفٍ وأرقامٍ فقط',
+    'array'                => 'يجب أن يكون الحقل :attribute ًمصفوفة',
+    'before'               => 'يجب على الحقل :attribute أن يكون تاريخًا سابقًا للتاريخ :date.',
+    'before_or_equal'      => 'The :attribute must be a date before or equal to :date.',
+    'between'              => [
+        'numeric' => 'يجب أن تكون قيمة :attribute بين :min و :max.',
+        'file'    => 'يجب أن يكون حجم الملف :attribute بين :min و :max كيلوبايت.',
+        'string'  => 'يجب أن يكون عدد حروف النّص :attribute بين :min و :max',
+        'array'   => 'يجب أن يحتوي :attribute على عدد من العناصر بين :min و :max',
+    ],
+    'boolean'              => 'يجب أن تكون قيمة الحقل :attribute إما true أو false ',
+    'confirmed'            => 'حقل التأكيد غير مُطابق للحقل :attribute',
+    'date'                 => 'الحقل :attribute ليس تاريخًا صحيحًا',
+    'date_format'          => 'لا يتوافق الحقل :attribute مع الشكل :format.',
+    'different'            => 'يجب أن يكون الحقلان :attribute و :other مُختلفان',
+    'digits'               => 'يجب أن يحتوي الحقل :attribute على :digits رقمًا/أرقام',
+    'digits_between'       => 'يجب أن يحتوي الحقل :attribute بين :min و :max رقمًا/أرقام ',
+    'dimensions'           => 'الـ :attribute يحتوي على أبعاد صورة غير صالحة.',
+    'distinct'             => 'للحقل :attribute قيمة مُكرّرة.',
+    'email'                => 'يجب أن يكون :attribute عنوان بريد إلكتروني صحيح البُنية',
+    'exists'               => 'الحقل :attribute لاغٍ',
+    'file'                 => 'الـ :attribute يجب أن يكون من ملفا.',
+    'filled'               => 'الحقل :attribute إجباري',
+    'image'                => 'يجب أن يكون الحقل :attribute صورةً',
+    'in'                   => 'الحقل :attribute لاغٍ',
+    'in_array'             => 'الحقل :attribute غير موجود في :other.',
+    'integer'              => 'يجب أن يكون الحقل :attribute عددًا صحيحًا',
+    'ip'                   => 'يجب أن يكون الحقل :attribute عنوان IP ذا بُنية صحيحة',
+    'json'                 => 'يجب أن يكون الحقل :attribute نصا من نوع JSON.',
+    'max'                  => [
+        'numeric' => 'يجب أن تكون قيمة الحقل :attribute مساوية أو أصغر لـ :max.',
+        'file'    => 'يجب أن لا يتجاوز حجم الملف :attribute :max كيلوبايت',
+        'string'  => 'يجب أن لا يتجاوز طول النّص :attribute :max حروفٍ/حرفًا',
+        'array'   => 'يجب أن لا يحتوي الحقل :attribute على أكثر من :max عناصر/عنصر.',
+    ],
+    'mimes'                => 'يجب أن يكون الحقل ملفًا من نوع : :values.',
+    'mimetypes'            => 'يجب أن يكون الحقل ملفًا من نوع : :values.',
+    'min'                  => [
+        'numeric' => 'يجب أن تكون قيمة الحقل :attribute مساوية أو أكبر لـ :min.',
+        'file'    => 'يجب أن يكون حجم الملف :attribute على الأقل :min كيلوبايت',
+        'string'  => 'يجب أن يكون طول النص :attribute على الأقل :min حروفٍ/حرفًا',
+        'array'   => 'يجب أن يحتوي الحقل :attribute على الأقل على :min عُنصرًا/عناصر',
+    ],
+    'not_in'               => 'الحقل :attribute لاغٍ',
+    'numeric'              => 'يجب على الحقل :attribute أن يكون رقمًا',
+    'present'              => 'يجب تقديم الحقل :attribute',
+    'regex'                => 'صيغة الحقل :attribute .غير صحيحة',
+    'required'             => 'الحقل :attribute مطلوب.',
+    'required_if'          => 'الحقل :attribute مطلوب في حال ما إذا كان :other يساوي :value.',
+    'required_unless'      => 'الحقل :attribute مطلوب في حال ما لم يكن :other يساوي :values.',
+    'required_with'        => 'الحقل :attribute إذا توفّر :values.',
+    'required_with_all'    => 'الحقل :attribute إذا توفّر :values.',
+    'required_without'     => 'الحقل :attribute إذا لم يتوفّر :values.',
+    'required_without_all' => 'الحقل :attribute إذا لم يتوفّر :values.',
+    'same'                 => 'يجب أن يتطابق الحقل :attribute مع :other',
+    'size'                 => [
+        'numeric' => 'يجب أن تكون قيمة الحقل :attribute مساوية لـ :size',
+        'file'    => 'يجب أن يكون حجم الملف :attribute :size كيلوبايت',
+        'string'  => 'يجب أن يحتوي النص :attribute على :size حروفٍ/حرفًا بالظبط',
+        'array'   => 'يجب أن يحتوي الحقل :attribute على :size عنصرٍ/عناصر بالظبط',
+    ],
+    'string'               => 'يجب أن يكون الحقل :attribute نصآ.',
+    'timezone'             => 'يجب أن يكون :attribute نطاقًا زمنيًا صحيحًا',
+    'unique'               => 'قيمة الحقل :attribute مُستخدمة من قبل',
+    'uploaded'             => 'فشل في تحميل الـ :attribute',
+    'url'                  => 'صيغة الرابط :attribute غير صحيحة',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Custom Validation Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify custom validation messages for attributes using the
+    | convention "attribute.rule" to name the lines. This makes it quick to
+    | specify a specific custom language line for a given attribute rule.
+    |
+    */
+
+    'custom'               => [
+        'attribute-name' => [
+            'rule-name' => 'custom-message',
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Custom Validation Attributes
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used to swap attribute place-holders
+    | with something more reader friendly such as E-Mail Address instead
+    | of "email". This simply helps us make messages a little cleaner.
+    |
+    */
+
+    'attributes'           => [
+        'name'                  => 'الاسم',
+        'username'              => 'اسم المُستخدم',
+        'email'                 => 'البريد الالكتروني',
+        'first_name'            => 'الاسم',
+        'last_name'             => 'اسم العائلة',
+        'password'              => 'كلمة  المرو',
+        'password_confirmation' => 'تأكيد كلمة المرور',
+        'city'                  => 'المدينة',
+        'country'               => 'الدولة',
+        'address'               => 'العنوان',
+        'phone'                 => 'الهاتف',
+        'mobile'                => 'الجوال',
+        'age'                   => 'العمر',
+        'sex'                   => 'الجنس',
+        'gender'                => 'النوع',
+        'day'                   => 'اليوم',
+        'month'                 => 'الشهر',
+        'year'                  => 'السنة',
+        'hour'                  => 'ساعة',
+        'minute'                => 'دقيقة',
+        'second'                => 'ثانية',
+        'title'                 => 'اللقب',
+        'content'               => 'المُحتوى',
+        'description'           => 'الوصف',
+        'excerpt'               => 'المُلخص',
+        'date'                  => 'التاريخ',
+        'time'                  => 'الوقت',
+        'available'             => 'مُتاح',
+        'size'                  => 'الحجم',
+    ],
+
+];

--- a/resources/lang/es/auth.php
+++ b/resources/lang/es/auth.php
@@ -1,0 +1,19 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Authentication Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used during authentication for various
+    | messages that we need to display to the user. You are free to modify
+    | these language lines according to your application's requirements.
+    |
+    */
+
+    'failed'   => 'Estas credenciales no coinciden con nuestros registros.',
+    'throttle' => 'Demasiados intentos de acceso. Por favor intente nuevamente en :seconds segundos.',
+
+];

--- a/resources/lang/es/pagination.php
+++ b/resources/lang/es/pagination.php
@@ -1,0 +1,19 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Pagination Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used by the paginator library to build
+    | the simple pagination links. You are free to change them to anything
+    | you want to customize your views to better match your application.
+    |
+    */
+
+    'previous' => '&laquo; Anterior',
+    'next'     => 'Siguiente &raquo;',
+
+];

--- a/resources/lang/es/passwords.php
+++ b/resources/lang/es/passwords.php
@@ -1,0 +1,22 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Password Reminder Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are the default lines which match reasons
+    | that are given by the password broker for a password update attempt
+    | has failed, such as for an invalid token or invalid new password.
+    |
+    */
+
+    'password' => 'Las contraseñas deben coincidir y contener al menos 6 caracteres',
+    'reset'    => '¡Tu contraseña ha sido restablecida!',
+    'sent'     => '¡Te hemos enviado por correo el enlace para restablecer tu contraseña!',
+    'token'    => 'El token de recuperación de contraseña es inválido.',
+    'user'     => 'No podemos encontrar ningún usuario con ese correo electrónico.',
+
+];

--- a/resources/lang/es/validation.php
+++ b/resources/lang/es/validation.php
@@ -1,0 +1,149 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Validation Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines contain the default error messages used by
+    | the validator class. Some of these rules have multiple versions such
+    | such as the size rules. Feel free to tweak each of these messages.
+    |
+    */
+
+    'accepted'             => ':attribute debe ser aceptado.',
+    'active_url'           => ':attribute no es una URL válida.',
+    'after'                => ':attribute debe ser una fecha posterior a :date.',
+    'after_or_equal'       => ':attribute debe ser una fecha posterior o igual a :date.',
+    'alpha'                => ':attribute sólo debe contener letras.',
+    'alpha_dash'           => ':attribute sólo debe contener letras, números y guiones.',
+    'alpha_num'            => ':attribute sólo debe contener letras y números.',
+    'array'                => ':attribute debe ser un conjunto.',
+    'before'               => ':attribute debe ser una fecha anterior a :date.',
+    'before_or_equal'      => ':attribute debe ser una fecha anterior o igual a :date.',
+    'between'              => [
+        'numeric' => ':attribute tiene que estar entre :min - :max.',
+        'file'    => ':attribute debe pesar entre :min - :max kilobytes.',
+        'string'  => ':attribute tiene que tener entre :min - :max caracteres.',
+        'array'   => ':attribute tiene que tener entre :min - :max ítems.',
+    ],
+    'boolean'              => 'El campo :attribute debe tener un valor verdadero o falso.',
+    'confirmed'            => 'La confirmación de :attribute no coincide.',
+    'date'                 => ':attribute no es una fecha válida.',
+    'date_format'          => ':attribute no corresponde al formato :format.',
+    'different'            => ':attribute y :other deben ser diferentes.',
+    'digits'               => ':attribute debe tener :digits dígitos.',
+    'digits_between'       => ':attribute debe tener entre :min y :max dígitos.',
+    'dimensions'           => 'Las dimensiones de la imagen :attribute no son válidas.',
+    'distinct'             => 'El campo :attribute contiene un valor duplicado.',
+    'email'                => ':attribute no es un correo válido',
+    'exists'               => ':attribute es inválido.',
+    'file'                 => 'El campo :attribute debe ser un archivo.',
+    'filled'               => 'El campo :attribute es obligatorio.',
+    'image'                => ':attribute debe ser una imagen.',
+    'in'                   => ':attribute es inválido.',
+    'in_array'             => 'El campo :attribute no existe en :other.',
+    'integer'              => ':attribute debe ser un número entero.',
+    'ip'                   => ':attribute debe ser una dirección IP válida.',
+    'json'                 => 'El campo :attribute debe tener una cadena JSON válida.',
+    'max'                  => [
+        'numeric' => ':attribute no debe ser mayor a :max.',
+        'file'    => ':attribute no debe ser mayor que :max kilobytes.',
+        'string'  => ':attribute no debe ser mayor que :max caracteres.',
+        'array'   => ':attribute no debe tener más de :max elementos.',
+    ],
+    'mimes'                => ':attribute debe ser un archivo con formato: :values.',
+    'mimetypes'            => ':attribute debe ser un archivo con formato: :values.',
+    'min'                  => [
+        'numeric' => 'El tamaño de :attribute debe ser de al menos :min.',
+        'file'    => 'El tamaño de :attribute debe ser de al menos :min kilobytes.',
+        'string'  => ':attribute debe contener al menos :min caracteres.',
+        'array'   => ':attribute debe tener al menos :min elementos.',
+    ],
+    'not_in'               => ':attribute es inválido.',
+    'numeric'              => ':attribute debe ser numérico.',
+    'present'              => 'El campo :attribute debe estar presente.',
+    'regex'                => 'El formato de :attribute es inválido.',
+    'required'             => 'El campo :attribute es obligatorio.',
+    'required_if'          => 'El campo :attribute es obligatorio cuando :other es :value.',
+    'required_unless'      => 'El campo :attribute es obligatorio a menos que :other esté en :values.',
+    'required_with'        => 'El campo :attribute es obligatorio cuando :values está presente.',
+    'required_with_all'    => 'El campo :attribute es obligatorio cuando :values está presente.',
+    'required_without'     => 'El campo :attribute es obligatorio cuando :values no está presente.',
+    'required_without_all' => 'El campo :attribute es obligatorio cuando ninguno de :values estén presentes.',
+    'same'                 => ':attribute y :other deben coincidir.',
+    'size'                 => [
+        'numeric' => 'El tamaño de :attribute debe ser :size.',
+        'file'    => 'El tamaño de :attribute debe ser :size kilobytes.',
+        'string'  => ':attribute debe contener :size caracteres.',
+        'array'   => ':attribute debe contener :size elementos.',
+    ],
+    'string'               => 'El campo :attribute debe ser una cadena de caracteres.',
+    'timezone'             => 'El :attribute debe ser una zona válida.',
+    'unique'               => ':attribute ya ha sido registrado.',
+    'uploaded'             => 'Subir :attribute ha fallado.',
+    'url'                  => 'El formato :attribute es inválido.',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Custom Validation Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify custom validation messages for attributes using the
+    | convention "attribute.rule" to name the lines. This makes it quick to
+    | specify a specific custom language line for a given attribute rule.
+    |
+    */
+
+    'custom'               => [
+        'attribute-name' => [
+            'rule-name' => 'custom-message',
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Custom Validation Attributes
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used to swap attribute place-holders
+    | with something more reader friendly such as E-Mail Address instead
+    | of "email". This simply helps us make messages a little cleaner.
+    |
+    */
+
+    'attributes'           => [
+        'name'                  => 'nombre',
+        'username'              => 'usuario',
+        'email'                 => 'correo electrónico',
+        'first_name'            => 'nombre',
+        'last_name'             => 'apellido',
+        'password'              => 'contraseña',
+        'password_confirmation' => 'confirmación de la contraseña',
+        'city'                  => 'ciudad',
+        'country'               => 'país',
+        'address'               => 'dirección',
+        'phone'                 => 'teléfono',
+        'mobile'                => 'móvil',
+        'age'                   => 'edad',
+        'sex'                   => 'sexo',
+        'gender'                => 'género',
+        'year'                  => 'año',
+        'month'                 => 'mes',
+        'day'                   => 'día',
+        'hour'                  => 'hora',
+        'minute'                => 'minuto',
+        'second'                => 'segundo',
+        'title'                 => 'título',
+        'body'                  => 'contenido',
+        'description'           => 'descripción',
+        'excerpt'               => 'extracto',
+        'date'                  => 'fecha',
+        'time'                  => 'hora',
+        'subject'               => 'asunto',
+        'message'               => 'mensaje',
+    ],
+
+];

--- a/resources/lang/fr/auth.php
+++ b/resources/lang/fr/auth.php
@@ -1,0 +1,19 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Authentication Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used during authentication for various
+    | messages that we need to display to the user. You are free to modify
+    | these language lines according to your application's requirements.
+    |
+    */
+
+    'failed'   => 'Ces identifiants ne correspondent pas à nos enregistrements',
+    'throttle' => 'Trop de tentatives de connexion. Veuillez essayer de nouveau dans :seconds secondes.',
+
+];

--- a/resources/lang/fr/pagination.php
+++ b/resources/lang/fr/pagination.php
@@ -1,0 +1,19 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Pagination Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used by the paginator library to build
+    | the simple pagination links. You are free to change them to anything
+    | you want to customize your views to better match your application.
+    |
+    */
+
+    'previous' => '&laquo; Précédent',
+    'next'     => 'Suivant &raquo;',
+
+];

--- a/resources/lang/fr/passwords.php
+++ b/resources/lang/fr/passwords.php
@@ -1,0 +1,22 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Password Reminder Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are the default lines which match reasons
+    | that are given by the password broker for a password update attempt
+    | has failed, such as for an invalid token or invalid new password.
+    |
+    */
+
+    'password' => 'Les mots de passe doivent contenir au moins six caractères et doivent être identiques.',
+    'reset'    => 'Votre mot de passe a été réinitialisé !',
+    'sent'     => 'Nous vous avons envoyé par courriel le lien de réinitialisation du mot de passe !',
+    'token'    => "Ce jeton de réinitialisation du mot de passe n'est pas valide.",
+    'user'     => "Aucun utilisateur n'a été trouvé avec cette adresse e-mail.",
+
+];

--- a/resources/lang/fr/validation.php
+++ b/resources/lang/fr/validation.php
@@ -1,0 +1,149 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Validation Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines contain the default error messages used by
+    | the validator class. Some of these rules have multiple versions such
+    | such as the size rules. Feel free to tweak each of these messages.
+    |
+    */
+
+    'accepted'             => 'Le champ :attribute doit être accepté.',
+    'active_url'           => "Le champ :attribute n'est pas une URL valide.",
+    'after'                => 'Le champ :attribute doit être une date postérieure au :date.',
+    'after_or_equal'       => 'Le champ :attribute doit être une date postérieure ou égale au :date.',
+    'alpha'                => 'Le champ :attribute doit seulement contenir des lettres.',
+    'alpha_dash'           => 'Le champ :attribute doit seulement contenir des lettres, des chiffres et des tirets.',
+    'alpha_num'            => 'Le champ :attribute doit seulement contenir des chiffres et des lettres.',
+    'array'                => 'Le champ :attribute doit être un tableau.',
+    'before'               => 'Le champ :attribute doit être une date antérieure au :date.',
+    'before_or_equal'      => 'Le champ :attribute doit être une date antérieure ou égale au :date.',
+    'between'              => [
+        'numeric' => 'La valeur de :attribute doit être comprise entre :min et :max.',
+        'file'    => 'La taille du fichier de :attribute doit être comprise entre :min et :max kilo-octets.',
+        'string'  => 'Le texte :attribute doit contenir entre :min et :max caractères.',
+        'array'   => 'Le tableau :attribute doit contenir entre :min et :max éléments.',
+    ],
+    'boolean'              => 'Le champ :attribute doit être vrai ou faux.',
+    'confirmed'            => 'Le champ de confirmation :attribute ne correspond pas.',
+    'date'                 => "Le champ :attribute n'est pas une date valide.",
+    'date_format'          => 'Le champ :attribute ne correspond pas au format :format.',
+    'different'            => 'Les champs :attribute et :other doivent être différents.',
+    'digits'               => 'Le champ :attribute doit contenir :digits chiffres.',
+    'digits_between'       => 'Le champ :attribute doit contenir entre :min et :max chiffres.',
+    'dimensions'           => "La taille de l'image :attribute n'est pas conforme.",
+    'distinct'             => 'Le champ :attribute a une valeur dupliquée.',
+    'email'                => 'Le champ :attribute doit être une adresse e-mail valide.',
+    'exists'               => 'Le champ :attribute sélectionné est invalide.',
+    'file'                 => 'Le champ :attribute doit être un fichier.',
+    'filled'               => 'Le champ :attribute est obligatoire.',
+    'image'                => 'Le champ :attribute doit être une image.',
+    'in'                   => 'Le champ :attribute est invalide.',
+    'in_array'             => 'Le champ :attribute n\'existe pas dans :other.',
+    'integer'              => 'Le champ :attribute doit être un entier.',
+    'ip'                   => 'Le champ :attribute doit être une adresse IP valide.',
+    'json'                 => 'Le champ :attribute doit être un document JSON valide.',
+    'max'                  => [
+        'numeric' => 'La valeur de :attribute ne peut être supérieure à :max.',
+        'file'    => 'La taille du fichier de :attribute ne peut pas dépasser :max kilo-octets.',
+        'string'  => 'Le texte de :attribute ne peut contenir plus de :max caractères.',
+        'array'   => 'Le tableau :attribute ne peut contenir plus de :max éléments.',
+    ],
+    'mimes'                => 'Le champ :attribute doit être un fichier de type : :values.',
+    'mimetypes'            => 'Le champ :attribute doit être un fichier de type : :values.',
+    'min'                  => [
+        'numeric' => 'La valeur de :attribute doit être supérieure ou égale à :min.',
+        'file'    => 'La taille du fichier de :attribute doit être supérieure à :min kilo-octets.',
+        'string'  => 'Le texte :attribute doit contenir au moins :min caractères.',
+        'array'   => 'Le tableau :attribute doit contenir au moins :min éléments.',
+    ],
+    'not_in'               => "Le champ :attribute sélectionné n'est pas valide.",
+    'numeric'              => 'Le champ :attribute doit contenir un nombre.',
+    'present'              => 'Le champ :attribute doit être présent.',
+    'regex'                => 'Le format du champ :attribute est invalide.',
+    'required'             => 'Le champ :attribute est obligatoire.',
+    'required_if'          => 'Le champ :attribute est obligatoire quand la valeur de :other est :value.',
+    'required_unless'      => 'Le champ :attribute est obligatoire sauf si :other est :values.',
+    'required_with'        => 'Le champ :attribute est obligatoire quand :values est présent.',
+    'required_with_all'    => 'Le champ :attribute est obligatoire quand :values est présent.',
+    'required_without'     => "Le champ :attribute est obligatoire quand :values n'est pas présent.",
+    'required_without_all' => "Le champ :attribute est requis quand aucun de :values n'est présent.",
+    'same'                 => 'Les champs :attribute et :other doivent être identiques.',
+    'size'                 => [
+        'numeric' => 'La valeur de :attribute doit être :size.',
+        'file'    => 'La taille du fichier de :attribute doit être de :size kilo-octets.',
+        'string'  => 'Le texte de :attribute doit contenir :size caractères.',
+        'array'   => 'Le tableau :attribute doit contenir :size éléments.',
+    ],
+    'string'               => 'Le champ :attribute doit être une chaîne de caractères.',
+    'timezone'             => 'Le champ :attribute doit être un fuseau horaire valide.',
+    'unique'               => 'La valeur du champ :attribute est déjà utilisée.',
+    'uploaded'             => "Le fichier du champ :attribute n'a pu être téléchargé.",
+    'url'                  => "Le format de l'URL de :attribute n'est pas valide.",
+
+    /*
+    |--------------------------------------------------------------------------
+    | Custom Validation Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify custom validation messages for attributes using the
+    | convention "attribute.rule" to name the lines. This makes it quick to
+    | specify a specific custom language line for a given attribute rule.
+    |
+    */
+
+    'custom'               => [
+        'attribute-name' => [
+            'rule-name' => 'custom-message',
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Custom Validation Attributes
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used to swap attribute place-holders
+    | with something more reader friendly such as E-Mail Address instead
+    | of "email". This simply helps us make messages a little cleaner.
+    |
+    */
+
+    'attributes'           => [
+        'name'                  => 'Nom',
+        'username'              => 'Pseudo',
+        'email'                 => 'Adresse e-mail',
+        'first_name'            => 'Prénom',
+        'last_name'             => 'Nom',
+        'password'              => 'Mot de passe',
+        'password_confirmation' => 'Confirmation du mot de passe',
+        'city'                  => 'Ville',
+        'country'               => 'Pays',
+        'address'               => 'Adresse',
+        'phone'                 => 'Téléphone',
+        'mobile'                => 'Portable',
+        'age'                   => 'Age',
+        'sex'                   => 'Sexe',
+        'gender'                => 'Genre',
+        'day'                   => 'Jour',
+        'month'                 => 'Mois',
+        'year'                  => 'Année',
+        'hour'                  => 'Heure',
+        'minute'                => 'Minute',
+        'second'                => 'Seconde',
+        'title'                 => 'Titre',
+        'content'               => 'Contenu',
+        'description'           => 'Description',
+        'excerpt'               => 'Extrait',
+        'date'                  => 'Date',
+        'time'                  => 'Heure',
+        'available'             => 'Disponible',
+        'size'                  => 'Taille',
+    ],
+
+];


### PR DESCRIPTION
This PR can solve #54 and #74 (based on the #115 PR too). Now we can get rid of the WithoutMiddleware trait on web routes testing and now we have correct form validations error displaying on web routes. In the future maybe we will have displaying errors from FormRequests authorization, but at the moment everything is ok. This PR is based on the DingoAPI documentation, and specifically [this](https://github.com/dingo/api/blob/master/src/Http/FormRequest.php) class... the future problem commented could be solved checking the Dingo Formrequest class again.

