### PR TITLE
add missing translations files

### DIFF
--- a/resources/lang/ar/auth.php
+++ b/resources/lang/ar/auth.php
@@ -1,0 +1,19 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Authentication Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used during authentication for various
+    | messages that we need to display to the user. You are free to modify
+    | these language lines according to your application's requirements.
+    |
+    */
+
+    'failed'   => 'بيانات الاعتماد هذه غير متطابقة مع البيانات المسجلة لدينا.',
+    'throttle' => 'عدد كبير جدا من محاولات الدخول. يرجى المحاولة مرة أخرى بعد :seconds ثانية.',
+
+];

--- a/resources/lang/ar/pagination.php
+++ b/resources/lang/ar/pagination.php
@@ -1,0 +1,19 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Pagination Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used by the paginator library to build
+    | the simple pagination links. You are free to change them to anything
+    | you want to customize your views to better match your application.
+    |
+    */
+
+    'previous' => '&laquo; السابق',
+    'next'     => 'التالي &raquo;',
+
+];

--- a/resources/lang/ar/passwords.php
+++ b/resources/lang/ar/passwords.php
@@ -1,0 +1,22 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Password Reminder Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are the default lines which match reasons
+    | that are given by the password broker for a password update attempt
+    | has failed, such as for an invalid token or invalid new password.
+    |
+    */
+
+    'password' => 'يجب أن لا يقل طول كلمة المرور عن ستة أحرف، كما يجب أن تتطابق مع حقل التأكيد',
+    'reset'    => 'تمت إعادة تعيين كلمة المرور',
+    'sent'     => 'تم إرسال تفاصيل استعادة كلمة المرور الخاصة بك إلى بريدك الإلكتروني',
+    'token'    => '.رمز استعادة كلمة المرور الذي أدخلته غير صحيح',
+    'user'     => 'لم يتم العثور على أيّ حسابٍ بهذا العنوان الإلكتروني',
+
+];

--- a/resources/lang/ar/validation.php
+++ b/resources/lang/ar/validation.php
@@ -1,0 +1,149 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Validation Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines contain the default error messages used by
+    | the validator class. Some of these rules have multiple versions such
+    | such as the size rules. Feel free to tweak each of these messages.
+    |
+    */
+
+    'accepted'             => 'يجب قبول الحقل :attribute',
+    'active_url'           => 'الحقل :attribute لا يُمثّل رابطًا صحيحًا',
+    'after'                => 'يجب على الحقل :attribute أن يكون تاريخًا لاحقًا للتاريخ :date.',
+    'after_or_equal'       => 'The :attribute must be a date after or equal to :date.',
+    'alpha'                => 'يجب أن لا يحتوي الحقل :attribute سوى على حروف',
+    'alpha_dash'           => 'يجب أن لا يحتوي الحقل :attribute على حروف، أرقام ومطّات.',
+    'alpha_num'            => 'يجب أن يحتوي :attribute على حروفٍ وأرقامٍ فقط',
+    'array'                => 'يجب أن يكون الحقل :attribute ًمصفوفة',
+    'before'               => 'يجب على الحقل :attribute أن يكون تاريخًا سابقًا للتاريخ :date.',
+    'before_or_equal'      => 'The :attribute must be a date before or equal to :date.',
+    'between'              => [
+        'numeric' => 'يجب أن تكون قيمة :attribute بين :min و :max.',
+        'file'    => 'يجب أن يكون حجم الملف :attribute بين :min و :max كيلوبايت.',
+        'string'  => 'يجب أن يكون عدد حروف النّص :attribute بين :min و :max',
+        'array'   => 'يجب أن يحتوي :attribute على عدد من العناصر بين :min و :max',
+    ],
+    'boolean'              => 'يجب أن تكون قيمة الحقل :attribute إما true أو false ',
+    'confirmed'            => 'حقل التأكيد غير مُطابق للحقل :attribute',
+    'date'                 => 'الحقل :attribute ليس تاريخًا صحيحًا',
+    'date_format'          => 'لا يتوافق الحقل :attribute مع الشكل :format.',
+    'different'            => 'يجب أن يكون الحقلان :attribute و :other مُختلفان',
+    'digits'               => 'يجب أن يحتوي الحقل :attribute على :digits رقمًا/أرقام',
+    'digits_between'       => 'يجب أن يحتوي الحقل :attribute بين :min و :max رقمًا/أرقام ',
+    'dimensions'           => 'الـ :attribute يحتوي على أبعاد صورة غير صالحة.',
+    'distinct'             => 'للحقل :attribute قيمة مُكرّرة.',
+    'email'                => 'يجب أن يكون :attribute عنوان بريد إلكتروني صحيح البُنية',
+    'exists'               => 'الحقل :attribute لاغٍ',
+    'file'                 => 'الـ :attribute يجب أن يكون من ملفا.',
+    'filled'               => 'الحقل :attribute إجباري',
+    'image'                => 'يجب أن يكون الحقل :attribute صورةً',
+    'in'                   => 'الحقل :attribute لاغٍ',
+    'in_array'             => 'الحقل :attribute غير موجود في :other.',
+    'integer'              => 'يجب أن يكون الحقل :attribute عددًا صحيحًا',
+    'ip'                   => 'يجب أن يكون الحقل :attribute عنوان IP ذا بُنية صحيحة',
+    'json'                 => 'يجب أن يكون الحقل :attribute نصا من نوع JSON.',
+    'max'                  => [
+        'numeric' => 'يجب أن تكون قيمة الحقل :attribute مساوية أو أصغر لـ :max.',
+        'file'    => 'يجب أن لا يتجاوز حجم الملف :attribute :max كيلوبايت',
+        'string'  => 'يجب أن لا يتجاوز طول النّص :attribute :max حروفٍ/حرفًا',
+        'array'   => 'يجب أن لا يحتوي الحقل :attribute على أكثر من :max عناصر/عنصر.',
+    ],
+    'mimes'                => 'يجب أن يكون الحقل ملفًا من نوع : :values.',
+    'mimetypes'            => 'يجب أن يكون الحقل ملفًا من نوع : :values.',
+    'min'                  => [
+        'numeric' => 'يجب أن تكون قيمة الحقل :attribute مساوية أو أكبر لـ :min.',
+        'file'    => 'يجب أن يكون حجم الملف :attribute على الأقل :min كيلوبايت',
+        'string'  => 'يجب أن يكون طول النص :attribute على الأقل :min حروفٍ/حرفًا',
+        'array'   => 'يجب أن يحتوي الحقل :attribute على الأقل على :min عُنصرًا/عناصر',
+    ],
+    'not_in'               => 'الحقل :attribute لاغٍ',
+    'numeric'              => 'يجب على الحقل :attribute أن يكون رقمًا',
+    'present'              => 'يجب تقديم الحقل :attribute',
+    'regex'                => 'صيغة الحقل :attribute .غير صحيحة',
+    'required'             => 'الحقل :attribute مطلوب.',
+    'required_if'          => 'الحقل :attribute مطلوب في حال ما إذا كان :other يساوي :value.',
+    'required_unless'      => 'الحقل :attribute مطلوب في حال ما لم يكن :other يساوي :values.',
+    'required_with'        => 'الحقل :attribute إذا توفّر :values.',
+    'required_with_all'    => 'الحقل :attribute إذا توفّر :values.',
+    'required_without'     => 'الحقل :attribute إذا لم يتوفّر :values.',
+    'required_without_all' => 'الحقل :attribute إذا لم يتوفّر :values.',
+    'same'                 => 'يجب أن يتطابق الحقل :attribute مع :other',
+    'size'                 => [
+        'numeric' => 'يجب أن تكون قيمة الحقل :attribute مساوية لـ :size',
+        'file'    => 'يجب أن يكون حجم الملف :attribute :size كيلوبايت',
+        'string'  => 'يجب أن يحتوي النص :attribute على :size حروفٍ/حرفًا بالظبط',
+        'array'   => 'يجب أن يحتوي الحقل :attribute على :size عنصرٍ/عناصر بالظبط',
+    ],
+    'string'               => 'يجب أن يكون الحقل :attribute نصآ.',
+    'timezone'             => 'يجب أن يكون :attribute نطاقًا زمنيًا صحيحًا',
+    'unique'               => 'قيمة الحقل :attribute مُستخدمة من قبل',
+    'uploaded'             => 'فشل في تحميل الـ :attribute',
+    'url'                  => 'صيغة الرابط :attribute غير صحيحة',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Custom Validation Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify custom validation messages for attributes using the
+    | convention "attribute.rule" to name the lines. This makes it quick to
+    | specify a specific custom language line for a given attribute rule.
+    |
+    */
+
+    'custom'               => [
+        'attribute-name' => [
+            'rule-name' => 'custom-message',
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Custom Validation Attributes
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used to swap attribute place-holders
+    | with something more reader friendly such as E-Mail Address instead
+    | of "email". This simply helps us make messages a little cleaner.
+    |
+    */
+
+    'attributes'           => [
+        'name'                  => 'الاسم',
+        'username'              => 'اسم المُستخدم',
+        'email'                 => 'البريد الالكتروني',
+        'first_name'            => 'الاسم',
+        'last_name'             => 'اسم العائلة',
+        'password'              => 'كلمة  المرو',
+        'password_confirmation' => 'تأكيد كلمة المرور',
+        'city'                  => 'المدينة',
+        'country'               => 'الدولة',
+        'address'               => 'العنوان',
+        'phone'                 => 'الهاتف',
+        'mobile'                => 'الجوال',
+        'age'                   => 'العمر',
+        'sex'                   => 'الجنس',
+        'gender'                => 'النوع',
+        'day'                   => 'اليوم',
+        'month'                 => 'الشهر',
+        'year'                  => 'السنة',
+        'hour'                  => 'ساعة',
+        'minute'                => 'دقيقة',
+        'second'                => 'ثانية',
+        'title'                 => 'اللقب',
+        'content'               => 'المُحتوى',
+        'description'           => 'الوصف',
+        'excerpt'               => 'المُلخص',
+        'date'                  => 'التاريخ',
+        'time'                  => 'الوقت',
+        'available'             => 'مُتاح',
+        'size'                  => 'الحجم',
+    ],
+
+];

--- a/resources/lang/fr/auth.php
+++ b/resources/lang/fr/auth.php
@@ -1,0 +1,19 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Authentication Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used during authentication for various
+    | messages that we need to display to the user. You are free to modify
+    | these language lines according to your application's requirements.
+    |
+    */
+
+    'failed'   => 'Ces identifiants ne correspondent pas à nos enregistrements',
+    'throttle' => 'Trop de tentatives de connexion. Veuillez essayer de nouveau dans :seconds secondes.',
+
+];

--- a/resources/lang/fr/pagination.php
+++ b/resources/lang/fr/pagination.php
@@ -1,0 +1,19 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Pagination Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used by the paginator library to build
+    | the simple pagination links. You are free to change them to anything
+    | you want to customize your views to better match your application.
+    |
+    */
+
+    'previous' => '&laquo; Précédent',
+    'next'     => 'Suivant &raquo;',
+
+];

--- a/resources/lang/fr/passwords.php
+++ b/resources/lang/fr/passwords.php
@@ -1,0 +1,22 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Password Reminder Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are the default lines which match reasons
+    | that are given by the password broker for a password update attempt
+    | has failed, such as for an invalid token or invalid new password.
+    |
+    */
+
+    'password' => 'Les mots de passe doivent contenir au moins six caractères et doivent être identiques.',
+    'reset'    => 'Votre mot de passe a été réinitialisé !',
+    'sent'     => 'Nous vous avons envoyé par courriel le lien de réinitialisation du mot de passe !',
+    'token'    => "Ce jeton de réinitialisation du mot de passe n'est pas valide.",
+    'user'     => "Aucun utilisateur n'a été trouvé avec cette adresse e-mail.",
+
+];

--- a/resources/lang/fr/validation.php
+++ b/resources/lang/fr/validation.php
@@ -1,0 +1,149 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Validation Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines contain the default error messages used by
+    | the validator class. Some of these rules have multiple versions such
+    | such as the size rules. Feel free to tweak each of these messages.
+    |
+    */
+
+    'accepted'             => 'Le champ :attribute doit être accepté.',
+    'active_url'           => "Le champ :attribute n'est pas une URL valide.",
+    'after'                => 'Le champ :attribute doit être une date postérieure au :date.',
+    'after_or_equal'       => 'Le champ :attribute doit être une date postérieure ou égale au :date.',
+    'alpha'                => 'Le champ :attribute doit seulement contenir des lettres.',
+    'alpha_dash'           => 'Le champ :attribute doit seulement contenir des lettres, des chiffres et des tirets.',
+    'alpha_num'            => 'Le champ :attribute doit seulement contenir des chiffres et des lettres.',
+    'array'                => 'Le champ :attribute doit être un tableau.',
+    'before'               => 'Le champ :attribute doit être une date antérieure au :date.',
+    'before_or_equal'      => 'Le champ :attribute doit être une date antérieure ou égale au :date.',
+    'between'              => [
+        'numeric' => 'La valeur de :attribute doit être comprise entre :min et :max.',
+        'file'    => 'La taille du fichier de :attribute doit être comprise entre :min et :max kilo-octets.',
+        'string'  => 'Le texte :attribute doit contenir entre :min et :max caractères.',
+        'array'   => 'Le tableau :attribute doit contenir entre :min et :max éléments.',
+    ],
+    'boolean'              => 'Le champ :attribute doit être vrai ou faux.',
+    'confirmed'            => 'Le champ de confirmation :attribute ne correspond pas.',
+    'date'                 => "Le champ :attribute n'est pas une date valide.",
+    'date_format'          => 'Le champ :attribute ne correspond pas au format :format.',
+    'different'            => 'Les champs :attribute et :other doivent être différents.',
+    'digits'               => 'Le champ :attribute doit contenir :digits chiffres.',
+    'digits_between'       => 'Le champ :attribute doit contenir entre :min et :max chiffres.',
+    'dimensions'           => "La taille de l'image :attribute n'est pas conforme.",
+    'distinct'             => 'Le champ :attribute a une valeur dupliquée.',
+    'email'                => 'Le champ :attribute doit être une adresse e-mail valide.',
+    'exists'               => 'Le champ :attribute sélectionné est invalide.',
+    'file'                 => 'Le champ :attribute doit être un fichier.',
+    'filled'               => 'Le champ :attribute est obligatoire.',
+    'image'                => 'Le champ :attribute doit être une image.',
+    'in'                   => 'Le champ :attribute est invalide.',
+    'in_array'             => 'Le champ :attribute n\'existe pas dans :other.',
+    'integer'              => 'Le champ :attribute doit être un entier.',
+    'ip'                   => 'Le champ :attribute doit être une adresse IP valide.',
+    'json'                 => 'Le champ :attribute doit être un document JSON valide.',
+    'max'                  => [
+        'numeric' => 'La valeur de :attribute ne peut être supérieure à :max.',
+        'file'    => 'La taille du fichier de :attribute ne peut pas dépasser :max kilo-octets.',
+        'string'  => 'Le texte de :attribute ne peut contenir plus de :max caractères.',
+        'array'   => 'Le tableau :attribute ne peut contenir plus de :max éléments.',
+    ],
+    'mimes'                => 'Le champ :attribute doit être un fichier de type : :values.',
+    'mimetypes'            => 'Le champ :attribute doit être un fichier de type : :values.',
+    'min'                  => [
+        'numeric' => 'La valeur de :attribute doit être supérieure ou égale à :min.',
+        'file'    => 'La taille du fichier de :attribute doit être supérieure à :min kilo-octets.',
+        'string'  => 'Le texte :attribute doit contenir au moins :min caractères.',
+        'array'   => 'Le tableau :attribute doit contenir au moins :min éléments.',
+    ],
+    'not_in'               => "Le champ :attribute sélectionné n'est pas valide.",
+    'numeric'              => 'Le champ :attribute doit contenir un nombre.',
+    'present'              => 'Le champ :attribute doit être présent.',
+    'regex'                => 'Le format du champ :attribute est invalide.',
+    'required'             => 'Le champ :attribute est obligatoire.',
+    'required_if'          => 'Le champ :attribute est obligatoire quand la valeur de :other est :value.',
+    'required_unless'      => 'Le champ :attribute est obligatoire sauf si :other est :values.',
+    'required_with'        => 'Le champ :attribute est obligatoire quand :values est présent.',
+    'required_with_all'    => 'Le champ :attribute est obligatoire quand :values est présent.',
+    'required_without'     => "Le champ :attribute est obligatoire quand :values n'est pas présent.",
+    'required_without_all' => "Le champ :attribute est requis quand aucun de :values n'est présent.",
+    'same'                 => 'Les champs :attribute et :other doivent être identiques.',
+    'size'                 => [
+        'numeric' => 'La valeur de :attribute doit être :size.',
+        'file'    => 'La taille du fichier de :attribute doit être de :size kilo-octets.',
+        'string'  => 'Le texte de :attribute doit contenir :size caractères.',
+        'array'   => 'Le tableau :attribute doit contenir :size éléments.',
+    ],
+    'string'               => 'Le champ :attribute doit être une chaîne de caractères.',
+    'timezone'             => 'Le champ :attribute doit être un fuseau horaire valide.',
+    'unique'               => 'La valeur du champ :attribute est déjà utilisée.',
+    'uploaded'             => "Le fichier du champ :attribute n'a pu être téléchargé.",
+    'url'                  => "Le format de l'URL de :attribute n'est pas valide.",
+
+    /*
+    |--------------------------------------------------------------------------
+    | Custom Validation Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify custom validation messages for attributes using the
+    | convention "attribute.rule" to name the lines. This makes it quick to
+    | specify a specific custom language line for a given attribute rule.
+    |
+    */
+
+    'custom'               => [
+        'attribute-name' => [
+            'rule-name' => 'custom-message',
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Custom Validation Attributes
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used to swap attribute place-holders
+    | with something more reader friendly such as E-Mail Address instead
+    | of "email". This simply helps us make messages a little cleaner.
+    |
+    */
+
+    'attributes'           => [
+        'name'                  => 'Nom',
+        'username'              => 'Pseudo',
+        'email'                 => 'Adresse e-mail',
+        'first_name'            => 'Prénom',
+        'last_name'             => 'Nom',
+        'password'              => 'Mot de passe',
+        'password_confirmation' => 'Confirmation du mot de passe',
+        'city'                  => 'Ville',
+        'country'               => 'Pays',
+        'address'               => 'Adresse',
+        'phone'                 => 'Téléphone',
+        'mobile'                => 'Portable',
+        'age'                   => 'Age',
+        'sex'                   => 'Sexe',
+        'gender'                => 'Genre',
+        'day'                   => 'Jour',
+        'month'                 => 'Mois',
+        'year'                  => 'Année',
+        'hour'                  => 'Heure',
+        'minute'                => 'Minute',
+        'second'                => 'Seconde',
+        'title'                 => 'Titre',
+        'content'               => 'Contenu',
+        'description'           => 'Description',
+        'excerpt'               => 'Extrait',
+        'date'                  => 'Date',
+        'time'                  => 'Heure',
+        'available'             => 'Disponible',
+        'size'                  => 'Taille',
+    ],
+
+];


### PR DESCRIPTION
This closes #118, now we have full translations strings for the supported languages... mainly on validation messages... these translations files were taken from this repo:

https://github.com/caouecs/Laravel-lang